### PR TITLE
chore: Disable ResizeObserver loop overlay on dev server

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -1,4 +1,14 @@
 module.exports = {
+  devServer: {
+    client: {
+      overlay: {
+        runtimeErrors: (error) => {
+          if (error.message === "ResizeObserver loop limit exceeded") return false;
+          return true;
+        }
+      }
+    }
+  },
   pluginOptions: {
     i18n: {
       locale: 'en',


### PR DESCRIPTION
**Purpose:**
To disable the ResizeObserver Loop overlay that pops up locally after logging into the demo account

![image](https://github.com/phrase/phrase-demo-app/assets/18315198/6b7c2dba-26d9-4e9f-9002-c387eb0d20d4)

References:
- https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded
- https://stackoverflow.com/questions/75774800/how-to-stop-resizeobserver-loop-limit-exceeded-error-from-appearing-in-react-a
- https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver